### PR TITLE
Switch Angular module for local storage

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -58,7 +58,7 @@
     "ngx-logger": "^5.0.12",
     "ngx-mapbox-gl": "^9.1.0",
     "ngx-markdown": "^15",
-    "ngx-web-storage": "^0.2.0",
+    "ngx-webstorage": "^13.0.1",
     "rxjs": "~7.5",
     "ts-jest": "^29.1",
     "tslib": "^2.6.0",

--- a/angular/src/app/app.component.spec.ts
+++ b/angular/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import {AppComponent} from './app.component';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {MatLegacySnackBar} from '@angular/material/legacy-snack-bar';
@@ -15,10 +15,13 @@ describe('AppComponent', () => {
     TestBed.configureTestingModule({
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       // Angular15 legacy hack
-      providers: [{provide: MatLegacySnackBar, useValue: {}}, {provide: MatLegacyDialog, useValue: {}}],
+      providers: [
+        {provide: MatLegacySnackBar, useValue: {}},
+        {provide: MatLegacyDialog, useValue: {}}
+      ],
       imports: [
         RouterTestingModule, MatSnackBarModule, LoggerTestingModule, HttpClientTestingModule,
-        WebStorageModule, MatIconTestingModule
+        NgxWebstorageModule.forRoot(), MatIconTestingModule
       ],
       declarations: [
         AppComponent

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -51,13 +51,15 @@ import {UserDisplayComponent} from '@shared/components/users/display/user-displa
 import {UserSelectComponent} from '@shared/components/users/select/user-select.component';
 import {VideoDetailsComponent} from './locatables/videos/video-details.component';
 import {VideoPlayerComponent} from './locatables/videos/video-player.component';
-import {WebStorageModule} from 'ngx-web-storage';
+// import {LocalStorageService} from 'ngx-webstorage'; // see successor below
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {YouTubePlayerModule} from '@angular/youtube-player';
 import {RadioComponent} from './radio/radio.component';
 import {MatLegacySliderModule as MatSliderModule} from '@angular/material/legacy-slider';
 import {RatingModule} from '@shared/modules/rating/rating.module';
 import { RemoveMeComponent } from './myprofile/remove-me.component';
 import { MAT_DATE_LOCALE } from '@angular/material/core';
+
 @NgModule({
   // "declarations:" make directives (including components and pipes) from the *current* module available to
   // *other* directives in the current module. Selectors of directives components or pipes are only matched against
@@ -120,10 +122,10 @@ import { MAT_DATE_LOCALE } from '@angular/material/core';
     MaterialModule, // here you'll find all the Material stuff
     MetricsModule,
     NgxMapboxGLModule,
+    NgxWebstorageModule.forRoot(),
     RatingModule, // Our Rating Module in shared/modules
     ReactiveFormsModule,
     TagCloudComponent, // instead of TagCloudModule, see https://github.com/d-koppenhagen/angular-tag-cloud-module/releases/tag/14.0.0
-    WebStorageModule.forRoot(),
     YouTubePlayerModule,
     MatSliderModule,
     RatingModule

--- a/angular/src/app/areas/area-tree.component.spec.ts
+++ b/angular/src/app/areas/area-tree.component.spec.ts
@@ -11,7 +11,7 @@ import {MatInputModule} from '@angular/material/input';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSelectModule} from '@angular/material/select';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {MatTreeModule} from '@angular/material/tree';
@@ -31,7 +31,7 @@ describe('AreaTreeComponent', () => {
       providers: [{provide: MatLegacySnackBar, useValue: {}}],
       imports: [MatIconTestingModule, MatCardModule, RouterTestingModule, LoggerTestingModule, HttpClientTestingModule,
         MatIconModule, MatSelectModule, MatTreeModule,
-        FormsModule, ReactiveFormsModule, MatSnackBarModule, MatInputModule, BrowserAnimationsModule, WebStorageModule],
+        FormsModule, ReactiveFormsModule, MatSnackBarModule, MatInputModule, BrowserAnimationsModule, NgxWebstorageModule.forRoot()],
       teardown: {destroyAfterEach: false}
     })
       .compileComponents();

--- a/angular/src/app/dishes/add/dish-add.component.spec.ts
+++ b/angular/src/app/dishes/add/dish-add.component.spec.ts
@@ -7,7 +7,8 @@ import {RouterTestingModule} from '@angular/router/testing';
 // imports: [RouterTestingModule, LoggerTestingModule, HttpClientTestingModule]
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule, WebStorageService} from 'ngx-web-storage';
+// import {WebStorageModule, WebStorageService} from 'ngx-web-storage';
+import {NgxWebstorageModule, LocalStorageService} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 
@@ -22,7 +23,7 @@ describe('DishAddComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatCardModule, MatIconTestingModule, RouterTestingModule, LoggerTestingModule, HttpClientTestingModule, FormsModule,
-        ReactiveFormsModule, WebStorageService, WebStorageModule],
+        ReactiveFormsModule, LocalStorageService, NgxWebstorageModule.forRoot()],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/dishes/detail/dish-detail.component.spec.ts
+++ b/angular/src/app/dishes/detail/dish-detail.component.spec.ts
@@ -7,7 +7,7 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {MatDialogModule} from '@angular/material/dialog';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {MarkdownModule} from 'ngx-markdown';
@@ -27,7 +27,7 @@ describe('DishDetailComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
       ],
       imports: [MatIconTestingModule, MatCardModule, RouterTestingModule, LoggerTestingModule, HttpClientTestingModule, MatDialogModule,
-        MatSnackBarModule, WebStorageModule, MarkdownModule, MatDatepickerModule],
+        MatSnackBarModule, MarkdownModule, MatDatepickerModule, NgxWebstorageModule.forRoot()],
       teardown: {destroyAfterEach: false}
 
     })

--- a/angular/src/app/dishes/edit/dish-edit.component.spec.ts
+++ b/angular/src/app/dishes/edit/dish-edit.component.spec.ts
@@ -8,7 +8,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatIconModule} from '@angular/material/icon';
 import {ClipboardModule} from '@angular/cdk/clipboard';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core'; // important for test
 
@@ -23,7 +23,7 @@ describe('DishEditComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatIconModule, MatCardModule, LoggerTestingModule, RouterTestingModule, HttpClientTestingModule, FormsModule, ReactiveFormsModule,
-        ClipboardModule, MatIconTestingModule, WebStorageModule],
+        ClipboardModule, MatIconTestingModule, NgxWebstorageModule.forRoot()],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/dishes/list/dishes.component.spec.ts
+++ b/angular/src/app/dishes/list/dishes.component.spec.ts
@@ -7,7 +7,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {MatIconModule} from '@angular/material/icon';
 import {MatCardModule} from '@angular/material/card';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {MatTableModule} from '@angular/material/table';
@@ -26,7 +26,7 @@ describe('DishesComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatIconModule, MatCardModule, RouterTestingModule, LoggerTestingModule, MatTabsModule,
-        HttpClientTestingModule, MatIconTestingModule, MatSnackBarModule, WebStorageModule, MatTableModule, FormsModule],
+        HttpClientTestingModule, MatIconTestingModule, MatSnackBarModule, NgxWebstorageModule.forRoot(), MatTableModule, FormsModule],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/home/home.component.spec.ts
+++ b/angular/src/app/home/home.component.spec.ts
@@ -5,7 +5,7 @@ import {LoggerTestingModule} from 'ngx-logger/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {MatIconModule} from '@angular/material/icon';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
@@ -23,7 +23,7 @@ describe('HomeComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatIconTestingModule, MatCardModule, LoggerTestingModule, HttpClientTestingModule, MatIconModule,
-        RouterTestingModule, WebStorageModule, MatSnackBarModule],
+        RouterTestingModule, NgxWebstorageModule.forRoot(), MatSnackBarModule],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/links/feeds/feed.component.spec.ts
+++ b/angular/src/app/links/feeds/feed.component.spec.ts
@@ -9,7 +9,7 @@ import {MatSelectModule} from '@angular/material/select';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 
 describe('FeedComponent', () => {
   let component: FeedComponent;
@@ -22,7 +22,7 @@ describe('FeedComponent', () => {
       ],
       declarations: [FeedComponent],
       imports: [LoggerTestingModule, RouterTestingModule,
-        MatIconTestingModule, MatSelectModule, NoopAnimationsModule, HttpClientTestingModule, MatSnackBarModule, WebStorageModule],
+        MatIconTestingModule, MatSelectModule, NoopAnimationsModule, HttpClientTestingModule, MatSnackBarModule, NgxWebstorageModule.forRoot()],
       teardown: {destroyAfterEach: false}
     })
       .compileComponents();

--- a/angular/src/app/locatables/photos/photo-details.component.spec.ts
+++ b/angular/src/app/locatables/photos/photo-details.component.spec.ts
@@ -6,7 +6,7 @@ import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {LayoutModule} from '@angular/cdk/layout';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatSelectModule} from '@angular/material/select';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
@@ -46,7 +46,7 @@ describe('PhotoDetailsComponent', () => {
     schemas: [
         CUSTOM_ELEMENTS_SCHEMA
     ],
-    imports: [MatIconTestingModule, FormsModule, LayoutModule, WebStorageModule, MatSelectModule, MatFormFieldModule, MatInputModule,
+    imports: [MatIconTestingModule, FormsModule, LayoutModule, NgxWebstorageModule.forRoot(), MatSelectModule, MatFormFieldModule, MatInputModule,
         ReactiveFormsModule, NoopAnimationsModule, HttpClientTestingModule, RouterTestingModule, LoggerTestingModule,
         MatButtonModule, MatDialogModule],
     teardown: { destroyAfterEach: false }

--- a/angular/src/app/locatables/posts/post-details.component.spec.ts
+++ b/angular/src/app/locatables/posts/post-details.component.spec.ts
@@ -6,7 +6,7 @@ import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {LayoutModule} from '@angular/cdk/layout';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatSelectModule} from '@angular/material/select';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
@@ -46,7 +46,7 @@ describe('PostDetailsComponent', () => {
     schemas: [
         CUSTOM_ELEMENTS_SCHEMA
     ],
-    imports: [MatIconTestingModule, FormsModule, LayoutModule, WebStorageModule, MatSelectModule, MatFormFieldModule, MatInputModule,
+    imports: [MatIconTestingModule, FormsModule, LayoutModule, NgxWebstorageModule.forRoot(), MatSelectModule, MatFormFieldModule, MatInputModule,
         ReactiveFormsModule, NoopAnimationsModule, HttpClientTestingModule, RouterTestingModule, LoggerTestingModule,
         MatButtonModule, MatDialogModule],
     teardown: { destroyAfterEach: false }

--- a/angular/src/app/locatables/search/location-search.component.spec.ts
+++ b/angular/src/app/locatables/search/location-search.component.spec.ts
@@ -15,8 +15,7 @@ import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatInputModule} from '@angular/material/input';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MatIconModule} from '@angular/material/icon';
-import {WebStorageModule} from 'ngx-web-storage';
-
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatMenuModule} from '@angular/material/menu';
 import {EntityType} from '@shared/domain/entities';
 import {ActivatedRoute} from '@angular/router';
@@ -77,7 +76,7 @@ describe('ToursComponent', () => {
         MatTabsModule,
         ReactiveFormsModule,
         RouterTestingModule,
-        WebStorageModule],
+        NgxWebstorageModule.forRoot()],
       teardown: {destroyAfterEach: false}
     })
       .compileComponents();

--- a/angular/src/app/locatables/tours/tour-details.component.spec.ts
+++ b/angular/src/app/locatables/tours/tour-details.component.spec.ts
@@ -7,7 +7,7 @@ import {LoggerTestingModule} from 'ngx-logger/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {MAT_DIALOG_DATA, MatDialogModule, MatDialogRef} from '@angular/material/dialog';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {Tour} from '@domain/location';
 import {EntityType} from '@shared/domain/entities';
 import {UntypedFormBuilder, FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -66,7 +66,7 @@ describe('TourDetailsComponent', () => {
         {provide: UntypedFormBuilder, useValue: formBuilder}, // for @ViewChild
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      imports: [MatIconTestingModule, FormsModule, LayoutModule, WebStorageModule, MatSelectModule, MatFormFieldModule, MatInputModule,
+      imports: [MatIconTestingModule, FormsModule, LayoutModule, NgxWebstorageModule.forRoot(), MatSelectModule, MatFormFieldModule, MatInputModule,
         ReactiveFormsModule, NoopAnimationsModule, HttpClientTestingModule, RouterTestingModule, LoggerTestingModule,
         MatButtonModule, MatLegacyDialogModule],
       declarations: [TourDetailsComponent],

--- a/angular/src/app/locatables/videos/video-details.component.spec.ts
+++ b/angular/src/app/locatables/videos/video-details.component.spec.ts
@@ -11,7 +11,7 @@ import {Link} from '@app/domain/link';
 import {MatButtonModule} from '@angular/material/button';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatSelectModule} from '@angular/material/select';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
@@ -39,7 +39,7 @@ describe('LinkInputComponent', () => {
     schemas: [
         CUSTOM_ELEMENTS_SCHEMA
     ],
-    imports: [MatIconTestingModule, FormsModule, LayoutModule, WebStorageModule, MatSelectModule, MatFormFieldModule, MatInputModule,
+    imports: [MatIconTestingModule, FormsModule, LayoutModule, NgxWebstorageModule.forRoot(), MatSelectModule, MatFormFieldModule, MatInputModule,
         ReactiveFormsModule, NoopAnimationsModule, HttpClientTestingModule, RouterTestingModule, LoggerTestingModule,
         MatButtonModule, MatDialogModule],
     teardown: { destroyAfterEach: false }

--- a/angular/src/app/locatables/videos/video-player.component.spec.ts
+++ b/angular/src/app/locatables/videos/video-player.component.spec.ts
@@ -9,7 +9,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatDialogModule} from '@angular/material/dialog';
 
 describe('YoutubePlayerDemoComponent', () => {
@@ -24,7 +24,7 @@ describe('YoutubePlayerDemoComponent', () => {
     declarations: [VideoPlayerComponent],
     imports: [YouTubePlayerModule, LoggerTestingModule, RouterTestingModule,
         MatIconTestingModule, NoopAnimationsModule, HttpClientTestingModule,
-        MatSnackBarModule, WebStorageModule, MatDialogModule],
+        MatSnackBarModule, NgxWebstorageModule.forRoot(), MatDialogModule],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/map/map.component.spec.ts_disabled
+++ b/angular/src/app/map/map.component.spec.ts_disabled
@@ -5,7 +5,7 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {NgxMapboxGLModule} from 'ngx-mapbox-gl';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
@@ -32,7 +32,7 @@ describe('MapComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatIconTestingModule, MatMenuModule, MatButtonModule, RouterTestingModule, LoggerTestingModule, HttpClientTestingModule, MatSnackBarModule,
-        WebStorageModule, NgxMapboxGLModule],
+        NgxWebstorageModule, NgxMapboxGLModule],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/myprofile/my-profile.component.spec.ts
+++ b/angular/src/app/myprofile/my-profile.component.spec.ts
@@ -3,7 +3,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MyProfileComponent} from './my-profile.component';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {LoggerTestingModule} from 'ngx-logger/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
@@ -31,7 +31,7 @@ describe('UserProfileComponent', () => {
         {provide: MatLegacyDialog, useValue: {}},
         {provide: MatLegacySnackBar, useValue: {}}
       ],
-      imports: [MatIconTestingModule, HttpClientTestingModule, LoggerTestingModule, WebStorageModule, RouterTestingModule, MatDialogModule, MatSnackBarModule],
+      imports: [MatIconTestingModule, HttpClientTestingModule, LoggerTestingModule, NgxWebstorageModule.forRoot(), RouterTestingModule, MatDialogModule, MatSnackBarModule],
       declarations: [MyProfileComponent],
       teardown: {destroyAfterEach: false}
     })

--- a/angular/src/app/notes/detail/note-details.component.spec.ts
+++ b/angular/src/app/notes/detail/note-details.component.spec.ts
@@ -13,7 +13,7 @@ import {MatIconModule} from '@angular/material/icon';
 // the corresponding jest test, so we have to do it ourselves. Import of MatDialogModule in beforeEach seems to be no longer necessary
 import {MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialogRef as MatDialogRef} from '@angular/material/legacy-dialog';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {MatTableModule} from '@angular/material/table';
@@ -54,7 +54,7 @@ describe('NoteDetailsComponent', () => {
     imports: [MatIconTestingModule, MatCardModule, LayoutModule, LoggerTestingModule, RouterTestingModule,
         HttpClientTestingModule,/* MatDialogModule,*/ MatTabsModule, MatTableModule,
       BrowserAnimationsModule, MatFormFieldModule, FormsModule, ReactiveFormsModule, MatSnackBarModule, MatInputModule,
-        MatIconModule, WebStorageModule, MatSelectModule, MatDatepickerModule, MatNativeDateModule],
+        MatIconModule, NgxWebstorageModule.forRoot(), MatSelectModule, MatDatepickerModule, MatNativeDateModule],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/notes/list/notes.component.spec.ts
+++ b/angular/src/app/notes/list/notes.component.spec.ts
@@ -11,7 +11,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MatIconModule} from '@angular/material/icon';
 import {MatDialogModule} from '@angular/material/dialog';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {MatTableModule} from '@angular/material/table';
@@ -35,7 +35,7 @@ describe('NotesComponent', () => {
       imports: [MatIconTestingModule, MatCardModule, LayoutModule, LoggerTestingModule, RouterTestingModule,
         HttpClientTestingModule, MatDialogModule, MatTabsModule, MatTableModule,
         FormsModule, ReactiveFormsModule, MatSnackBarModule, MatInputModule,
-        BrowserAnimationsModule, MatIconModule, WebStorageModule],
+        BrowserAnimationsModule, MatIconModule, NgxWebstorageModule.forRoot()],
       teardown: {destroyAfterEach: false}
     })
       .compileComponents();

--- a/angular/src/app/places/add/place-add.component.spec.ts
+++ b/angular/src/app/places/add/place-add.component.spec.ts
@@ -8,7 +8,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatIconModule} from '@angular/material/icon';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 
@@ -23,7 +23,7 @@ describe('PlaceAddComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatIconTestingModule, MatCardModule, RouterTestingModule, LoggerTestingModule,
-        HttpClientTestingModule, FormsModule, ReactiveFormsModule, MatIconModule, WebStorageModule],
+        HttpClientTestingModule, FormsModule, ReactiveFormsModule, MatIconModule, NgxWebstorageModule.forRoot()],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/places/detail/place-detail.component.spec.ts
+++ b/angular/src/app/places/detail/place-detail.component.spec.ts
@@ -8,7 +8,7 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {MatLegacyDialogModule} from '@angular/material/legacy-dialog';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA, SecurityContext} from '@angular/core';
 import {MarkdownModule} from 'ngx-markdown';
@@ -25,7 +25,7 @@ describe('PlaceDetailComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatIconTestingModule, MatCardModule, RouterTestingModule, LoggerTestingModule, MatSnackBarModule,
-        HttpClientTestingModule, MatLegacyDialogModule, MatSnackBarModule, WebStorageModule,
+        HttpClientTestingModule, MatLegacyDialogModule, MatSnackBarModule, NgxWebstorageModule.forRoot(),
         // https://github.com/jfcere/ngx-markdown/blob/master/lib/src/markdown.service.spec.ts
         MarkdownModule.forRoot({ sanitize: SecurityContext.HTML })],
     teardown: { destroyAfterEach: false }

--- a/angular/src/app/places/edit/place-edit.component.spec.ts
+++ b/angular/src/app/places/edit/place-edit.component.spec.ts
@@ -7,7 +7,7 @@ import {PlaceEditComponent} from './place-edit.component';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {ClipboardModule} from '@angular/cdk/clipboard';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core'; // important for test
 
@@ -22,7 +22,7 @@ describe('PlaceEditComponent', () => {
         CUSTOM_ELEMENTS_SCHEMA
     ],
     imports: [MatCardModule, LoggerTestingModule, RouterTestingModule, HttpClientTestingModule, FormsModule, ReactiveFormsModule,
-        ClipboardModule, MatIconTestingModule, WebStorageModule],
+        ClipboardModule, MatIconTestingModule, NgxWebstorageModule.forRoot()],
     teardown: { destroyAfterEach: false }
 })
       .compileComponents();

--- a/angular/src/app/radio/audio.service.spec.ts
+++ b/angular/src/app/radio/audio.service.spec.ts
@@ -4,13 +4,13 @@ import { AudioService } from './audio.service';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 
 describe('AudioService', () => {
   let service: AudioService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({imports: [LoggerTestingModule,HttpClientTestingModule,RouterTestingModule,WebStorageModule]});
+    TestBed.configureTestingModule({imports: [LoggerTestingModule,HttpClientTestingModule,RouterTestingModule,NgxWebstorageModule.forRoot()]});
     service = TestBed.inject(AudioService);
   });
 

--- a/angular/src/app/radio/radio.component.spec.ts
+++ b/angular/src/app/radio/radio.component.spec.ts
@@ -8,7 +8,7 @@ import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatLegacySnackBar} from '@angular/material/legacy-snack-bar';
 
@@ -25,7 +25,7 @@ describe('SongComponent', () => {
       providers: [{provide: MatLegacySnackBar, useValue: {}}],
       declarations: [RadioComponent],
       imports: [LoggerTestingModule, RouterTestingModule, FormsModule, ReactiveFormsModule,
-        MatIconTestingModule, NoopAnimationsModule, HttpClientTestingModule, MatSnackBarModule, WebStorageModule],
+        MatIconTestingModule, NoopAnimationsModule, HttpClientTestingModule, MatSnackBarModule, NgxWebstorageModule.forRoot()],
       teardown: {destroyAfterEach: false}
     })
       .compileComponents();

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.spec.ts
@@ -10,7 +10,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MatIconModule} from '@angular/material/icon';
 import {MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialogRef as MatDialogRef} from '@angular/material/legacy-dialog';
 import {MatCardModule} from '@angular/material/card';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {MatTableModule} from '@angular/material/table';
@@ -45,7 +45,7 @@ describe('ConfirmDialogComponent', () => {
       imports: [MatIconTestingModule, MatCardModule, LayoutModule, LoggerTestingModule, RouterTestingModule,
         HttpClientTestingModule, MatTabsModule, MatTableModule, MatLegacyDialogModule,
         BrowserAnimationsModule, MatFormFieldModule, FormsModule, ReactiveFormsModule, MatSnackBarModule, MatInputModule,
-        MatIconModule, WebStorageModule, MatSelectModule, MatDatepickerModule, MatNativeDateModule],
+        MatIconModule, NgxWebstorageModule.forRoot(), MatSelectModule, MatDatepickerModule, MatNativeDateModule],
       teardown: {destroyAfterEach: false}
     })
       .compileComponents();

--- a/angular/src/app/shared/components/users/display/user-display.component.spec.ts
+++ b/angular/src/app/shared/components/users/display/user-display.component.spec.ts
@@ -4,7 +4,7 @@ import {UserDisplayComponent} from './user-display.component';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 
 describe('UserDisplayComponent', () => {
   let component: UserDisplayComponent;
@@ -12,7 +12,7 @@ describe('UserDisplayComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, WebStorageModule],
+    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, NgxWebstorageModule.forRoot()],
     declarations: [UserDisplayComponent],
     teardown: { destroyAfterEach: false }
 })

--- a/angular/src/app/shared/components/users/select/user-select.component.spec.ts
+++ b/angular/src/app/shared/components/users/select/user-select.component.spec.ts
@@ -4,7 +4,7 @@ import {UserSelectComponent} from './user-select.component';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {LocalStorageService, NgxWebstorageModule} from 'ngx-webstorage';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {UntypedFormControl} from '@angular/forms';
 
@@ -17,7 +17,7 @@ describe('UserSelectComponent', () => {
     schemas: [
         CUSTOM_ELEMENTS_SCHEMA
     ],
-    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, WebStorageModule],
+    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, NgxWebstorageModule.forRoot()],
     declarations: [UserSelectComponent],
     teardown: { destroyAfterEach: false }
 })

--- a/angular/src/app/shared/guards/hilde.guard.spec.ts
+++ b/angular/src/app/shared/guards/hilde.guard.spec.ts
@@ -1,7 +1,7 @@
 import {TestBed} from '@angular/core/testing';
 
 import {HildeGuard} from './hilde.guard';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 
@@ -10,7 +10,7 @@ describe('AuthGuard', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [WebStorageModule, LoggerTestingModule, RouterTestingModule],
+    imports: [NgxWebstorageModule.forRoot(), LoggerTestingModule, RouterTestingModule],
     teardown: { destroyAfterEach: false }
 });
     guard = TestBed.inject(HildeGuard);

--- a/angular/src/app/shared/guards/hilde.guard.ts
+++ b/angular/src/app/shared/guards/hilde.guard.ts
@@ -1,7 +1,8 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
 import {Observable} from 'rxjs';
-import {WebStorageService} from 'ngx-web-storage';
+// import {WebStorageService} from 'ngx-web-storage';
+import {LocalStorageService} from 'ngx-webstorage';
 import {NGXLogger} from 'ngx-logger';
 
 export const PRE_LOGIN_URL_SESSION_KEY = 'preloginUrl';
@@ -17,7 +18,7 @@ export class HildeGuard implements CanActivate {
 
   private readonly className = 'HildeGuard';
 
-  constructor(private storage: WebStorageService,
+  constructor(private storage: LocalStorageService,
               private logger: NGXLogger,
               private router: Router) {
   }
@@ -25,10 +26,10 @@ export class HildeGuard implements CanActivate {
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    const previousPath = this.storage.session.get(PRE_LOGIN_URL_SESSION_KEY);
+    const previousPath = this.storage.retrieve(PRE_LOGIN_URL_SESSION_KEY);
     if (previousPath) {
       this.logger.info(`${this.className}.canActivate: ${PRE_LOGIN_URL_SESSION_KEY} found in session, redirecting to ${previousPath}`);
-      this.storage.session.remove(PRE_LOGIN_URL_SESSION_KEY); // clean for next home access
+      this.storage.clear(PRE_LOGIN_URL_SESSION_KEY); // clean for next home access
       this.router.navigateByUrl(previousPath);
       return false;
     } else {

--- a/angular/src/app/shared/modules/imagine/file-upload/file-upload.component.spec.ts
+++ b/angular/src/app/shared/modules/imagine/file-upload/file-upload.component.spec.ts
@@ -13,7 +13,7 @@ import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {MatTableModule} from '@angular/material/table';
 import {RouterTestingModule} from '@angular/router/testing';
 import {BytesizePipe} from '../../../pipes/bytesize.pipe';
-import {WebStorageModule} from 'ngx-web-storage';
+import {LocalStorageService, NgxWebstorageModule} from 'ngx-webstorage';
 import {MatLegacySnackBar} from '@angular/material/legacy-snack-bar';
 import {MatLegacyDialog} from '@angular/material/legacy-dialog';
 
@@ -29,7 +29,7 @@ fdescribe('FileUploadComponent', () => {
       ],
       // Angular15 legacy hack
       providers: [{provide: MatLegacySnackBar, useValue: {}}, {provide: MatLegacyDialog, useValue: {}}],
-      imports: [HttpClientTestingModule, FormsModule, ReactiveFormsModule, MatSnackBarModule, WebStorageModule,
+      imports: [HttpClientTestingModule, FormsModule, ReactiveFormsModule, MatSnackBarModule, NgxWebstorageModule.forRoot(),
         MatIconModule, LoggerTestingModule, ClipboardModule, MatDialogModule, MatTableModule, RouterTestingModule],
       teardown: {destroyAfterEach: false}
     })

--- a/angular/src/app/shared/modules/imagine/imagine.service.spec.ts
+++ b/angular/src/app/shared/modules/imagine/imagine.service.spec.ts
@@ -4,7 +4,7 @@ import {ImagineService} from './imagine.service';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 import {Authentication} from '@shared/services/auth.service';
 import {FileItem} from '@shared/modules/imagine/file-item';
 import {EntityType} from '@shared/domain/entities';
@@ -14,7 +14,7 @@ describe('FileService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, WebStorageModule],
+    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, NgxWebstorageModule.forRoot()],
     teardown: { destroyAfterEach: false }
 });
     service = TestBed.inject(ImagineService);

--- a/angular/src/app/shared/services/auth.service.spec.ts
+++ b/angular/src/app/shared/services/auth.service.spec.ts
@@ -4,14 +4,14 @@ import {Authentication, AuthService} from './auth.service';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 import {LoggerTestingModule} from 'ngx-logger/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {WebStorageModule} from 'ngx-web-storage';
+import {NgxWebstorageModule} from 'ngx-webstorage';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, WebStorageModule],
+    imports: [HttpClientTestingModule, LoggerTestingModule, RouterTestingModule, NgxWebstorageModule.forRoot()],
     teardown: { destroyAfterEach: false }
 });
     service = TestBed.inject(AuthService);

--- a/angular/src/app/shared/services/auth.service.ts
+++ b/angular/src/app/shared/services/auth.service.ts
@@ -6,7 +6,7 @@ import {NGXLogger} from 'ngx-logger';
 import {PRE_LOGIN_URL_SESSION_KEY} from '../guards/hilde.guard';
 import {Router} from '@angular/router';
 import {User, UserSummary} from '@app/domain/user';
-import {WebStorageService} from 'ngx-web-storage';
+import {LocalStorageService} from 'ngx-webstorage';
 import {environment} from '../../../environments/environment';
 import {map, share, shareReplay} from 'rxjs/operators';
 
@@ -47,7 +47,7 @@ export class AuthService {
     private logger: NGXLogger,
     private location: Location,
     private router: Router,
-    private storage: WebStorageService) {
+    private storage: LocalStorageService) {
     this.checkAuthentication(); // check if authenticated, and if so - load the user
   }
 
@@ -146,7 +146,7 @@ export class AuthService {
     // It will show a Spring Security generated login page with links to configured OIDC providers.
     const currentPath = this.location.path();
     this.logger.debug(`Storing currentPath in session $PRE_LOGIN_URL_SESSION_KEY $currentPath`);
-    this.storage.session.set(PRE_LOGIN_URL_SESSION_KEY, currentPath); // router.routerState.snapshot.url
+    this.storage.store(PRE_LOGIN_URL_SESSION_KEY, currentPath)
     this.logger.debug(`${this.className}.login`, location.origin, this.location.prepareExternalUrl('oauth2/authorization/cognito'));
     // location.href = `${location.origin}${this.location.prepareExternalUrl('oauth2/authorization/cognito')}`;
     location.href = `${environment.apiUrlRoot}/../..${this.location.prepareExternalUrl('oauth2/authorization/cognito')}`;
@@ -158,7 +158,7 @@ export class AuthService {
   logout() {
     this.logger.warn('logout user ');
     this.authenticationSubject.next(this.anonymousAuthentication);
-    this.storage.session.remove(PRE_LOGIN_URL_SESSION_KEY); // used for redirect after login
+    this.storage.clear(PRE_LOGIN_URL_SESSION_KEY); // clear from local storage, only used for redirect after login
     this.http.post(`${environment.apiUrlRoot}/logout`, {}, {observe: 'response'}).subscribe(
       response => {
         // const data = response.body; // returns logoutUrl null and idToken

--- a/angular/yarn.lock
+++ b/angular/yarn.lock
@@ -7829,10 +7829,12 @@ ngx-markdown@^15:
     mermaid "^9.1.2"
     prismjs "^1.28.0"
 
-ngx-web-storage@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ngx-web-storage/-/ngx-web-storage-0.2.0.tgz#bd5450abd44fa478ea22ed800612c594ae96b6f1"
-  integrity sha512-V0qIFuERHZPxnA95Hl54wJflLXhpzTdPOY3+2kYB4e1RqPYPDMD46WhWIOXnUqhbrp3U7wtGfg67NB1P5wNL3g==
+ngx-webstorage@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/ngx-webstorage/-/ngx-webstorage-13.0.1.tgz#04de259104167a339aa59575c2c3b64983ca47f2"
+  integrity sha512-CyKAqhIAmJQbdeIK1lqQZ7uSoVLPFV0StyjkANn96I36HN/RKtNw9+l7fQTfmavnZpmZ9ctffcpsXRHPzSZvlw==
+  dependencies:
+    tslib "^2.0.0"
 
 nice-napi@^1.0.2:
   version "1.0.2"
@@ -9621,7 +9623,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.3.0, tslib@^2.6.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
We need to replace the current solution, package *ngx-webstorage* (no 2nd hyphen) looks more up2date

```
ngcc-jest-processor: running ngcc
Processing legacy "View Engine" libraries:
- ngx-web-storage [main/commonjs] (git+https://github.com/tim-kuteev/ngx-web-storage.git)
Encourage the library authors to publish an Ivy distribution.
```

```
Old: https://github.com/tim-kuteev/ngx-web-storage
    "ngx-web-storage": "^0.2.0",

    import {WebStorageModule} from 'ngx-web-storage';

```

```
New: https://github.com/PillowPillow/ng2-webstorage
    "ngx-webstorage": "^13.0.1",
    import {LocalStorageService} from 'ngx-webstorage';
```


