### PR TITLE
feat(nginx): add dedicated server block for Node.js game reverse proxy

### DIFF
--- a/angular/Dockerfile
+++ b/angular/Dockerfile
@@ -31,6 +31,6 @@ COPY ${BASEDIR}/nginx/options-proxy-nginx.conf /etc/nginx/options-proxy-nginx.co
 CMD ["sh","-c", "cp /www/index.html /www/index.tmpl.html && \
       UI_STARTED=$(date +'%Y-%m-%dT%TZ') envsubst '$APP_VERSION $RELEASE_NAME $MAPBOX_ACCESS_TOKEN $IMPRINT_URL $UI_STARTED' </www/assets/window-env.tmpl.js >/www/assets/window-env.js  && \
       DYNAMIC_ENV_CHECKSUM=$(md5sum /www/assets/window-env.js|cut -f1 -d' ') envsubst '$DYNAMIC_ENV_CHECKSUM' </www/index.tmpl.html >/www/index.html  && \
-      envsubst '$SERVER_NAME_PATTERN $SERVER_NAMES $API_HOST $API_PORT $HEALTHBELLS_HOST $HEALTHBELLS_PORT $IMAGINE_HOST $IMAGINE_PORT' </etc/nginx/nginx.tmpl.conf >/etc/nginx/nginx.conf  && \
+      envsubst '$SERVER_NAME_PATTERN $SERVER_NAMES $SERVER_NAME_NODE $API_HOST $API_PORT $HEALTHBELLS_HOST $HEALTHBELLS_PORT $IMAGINE_HOST $IMAGINE_PORT' </etc/nginx/nginx.tmpl.conf >/etc/nginx/nginx.conf  && \
       nginx -c /etc/nginx/nginx.conf -t || cat /etc/nginx/nginx.conf  && \
       exec nginx -g 'daemon off;' "]

--- a/angular/nginx/nginx.conf
+++ b/angular/nginx/nginx.conf
@@ -59,9 +59,21 @@ http {
         application/rss+xml
         image/svg+xml;
 
+  # Standard nginx websocket-proxy pattern: only send "Connection: upgrade" when
+  # the client actually requested a protocol upgrade (socket.io/ws), otherwise
+  # fall back to "close" so plain HTTP requests don't force upgrade semantics.
+  # https://nginx.org/en/docs/http/websocket.html
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
   # HTTP Server on port 80, only used to enforce SSL by redirecting to https
   server {
-    server_name ${SERVER_NAMES};
+    # only one server block listens on port 80, so it's nginx's implicit default
+    # for that port and will match any Host header (including SERVER_NAME_NODE)
+    # regardless of what's listed here - kept explicit for clarity/documentation.
+    server_name ${SERVER_NAMES} ${SERVER_NAME_NODE};
     # hack for multipe conditions https://gist.github.com/jrom/1760790
     # match is case insensitive. pattern should reflect shared parts of the domain e.g. mydomain.net
     #if ($host ~* ${SERVER_NAME_PATTERN}) { (...)
@@ -208,6 +220,38 @@ http {
     # https://forum.frank-mankel.org/topic/144/let-s-encrypt-installieren/2
     # openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048  2>/dev/null takes about 30s
     ssl_dhparam /etc/ssl/certs/dhparam.pem; # managed by cloud init script
+  }
+
+  # Dedicated HTTPS server block for a Node.js browser game (Express + socket.io).
+  # The app serves its own static assets and handles websocket upgrades itself, so
+  # nginx here is a thin reverse proxy: everything (static files, API, websockets)
+  # is forwarded to the Node process on localhost:3000.
+  server {
+    server_name ${SERVER_NAME_NODE};
+
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    ## reuse the same wildcard/SAN cert as the main server block
+    ssl_certificate /etc/ssl/certs/fullchain.pem; # should be managed by Certbot
+    ssl_certificate_key /etc/ssl/certs/privkey.pem; # should be managed managed by Certbot
+    include /etc/nginx/options-ssl-nginx.conf;
+    ssl_dhparam /etc/ssl/certs/dhparam.pem; # managed by cloud init script
+
+    location / {
+      proxy_pass http://127.0.0.1:3000;
+      include /etc/nginx/options-proxy-nginx.conf;
+
+      # WebSocket support for socket.io realtime game state
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+
+      # socket.io long-poll/websocket connections stay open much longer than a
+      # typical REST call; the shared options-proxy-nginx.conf's 90s read/send
+      # timeouts would kill idle connections mid-game, so extend them here.
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
   }
 
 }


### PR DESCRIPTION
Adds a new HTTPS server block for ${SERVER_NAME_NODE} that proxies all traffic to a Node.js/Express + socket.io app on localhost:3000. The app serves its own static assets, so nginx acts as a thin TLS-terminating reverse proxy, reusing the existing wildcard cert.

- proxy_http_version 1.1 + Upgrade/Connection headers (map-based, only upgrades when the client requests it) for WebSocket support
- extended proxy_read_timeout/proxy_send_timeout to 3600s so idle socket.io connections aren't killed by the shared 90s proxy defaults
- SERVER_NAME_NODE added to the port-80 redirect block and to the Dockerfile's envsubst variable list