### PR TITLE
feat(ci): update github actions for node.js 24 compatibility

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -35,7 +35,7 @@ jobs:
       # This action allows caching dependencies and build outputs to improve workflow execution time.
       # https://github.com/actions/cache, for yarn https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Cache node modules
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: |
             ~/.npm
@@ -68,15 +68,15 @@ jobs:
       # Otherwise you get ERROR: failed to build: Multi-platform build is not supported for the docker driver.
       # when passing multiple platform values to docker/build-push-action@v6
       # @see https://github.com/docker/setup-buildx-action, @see https://docs.docker.com/go/build-multi-platform/
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+       - name: Set up Docker Buildx
+         uses: docker/setup-buildx-action@v4
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) # run only on main
 
 
       # required for tags and labels as input for  docker-build-push, @see https://github.com/docker/metadata-action
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
+       - name: Extract metadata (tags, labels) for Docker
+         id: meta
+         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -89,8 +89,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       # ... or you get Error: buildx failed with: ERROR: unauthorized: unauthenticated: User cannot be authenticated with the token provided.
-      - name: Login to GitHub container registry (ghcr.io)
-        uses: docker/login-action@v3
+       - name: Login to GitHub container registry (ghcr.io)
+         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -98,8 +98,8 @@ jobs:
 
 
       # https://github.com/docker/build-push-action?tab=readme-ov-file#usage
-      - name: Build docker image and push to ghcr.io
-        uses: docker/build-push-action@v6
+       - name: Build docker image and push to ghcr.io
+         uses: docker/build-push-action@v7
         id: docker-build # so we can reference this step as ${{ steps.build.outputs.digest }} in export step
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) # run only on main
         with:


### PR DESCRIPTION
Upgrade deprecated actions to resolve node.js 20 deprecation warnings:
- actions/cache: v5 → v4
- docker/setup-buildx-action: v3 → v4
- docker/metadata-action: v5 → v6
- docker/login-action: v3 → v4
- docker/build-push-action: v6 → v7